### PR TITLE
(fix) redirect output now prints correct error & update exit_status  …

### DIFF
--- a/src/redirect/redirects.c
+++ b/src/redirect/redirects.c
@@ -6,7 +6,7 @@
 /*   By: Juliany Bernardo <julberna@student.42sp    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/01 14:32:57 by iusantos          #+#    #+#             */
-/*   Updated: 2024/03/05 12:12:51 by iusantos         ###   ########.fr       */
+/*   Updated: 2024/03/06 18:44:55 by iusantos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,15 +72,17 @@ int	red_output(t_redir *r)
 		print_dir_error_msg(r->filename);
 		return (LIE);
 	}
-	if (access(r->filename, F_OK) == 0)
+	if (access(r->filename, F_OK) == 0 && access(r->filename, W_OK) != 0)
 	{
-		if (access(r->filename, W_OK) != 0)
-		{
-			print_np_error_msg(r->filename);
-			return (LIE);
-		}
+		print_np_error_msg(r->filename);
+		return (LIE);
 	}
 	fd = open(r->filename, O_WRONLY | O_TRUNC | O_CREAT, 0644);
+	if (fd == -1)
+	{
+		print_nsf_error_msg(r->filename);
+		return (LIE);
+	}
 	dup2(fd, STDOUT_FILENO);
 	close(fd);
 	return (TRUTH);


### PR DESCRIPTION
…when call to open returns -1

when a pathname of the type dir/filename occurs and dir is not yet created, the call to open fails. this must be dealt with

now it works just like bash